### PR TITLE
chore: Make test working on recent tox release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }} ${{ matrix.runner }}
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,10 @@ on:
       - '**'
   workflow_dispatch:
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: ${{ matrix.platform }} py${{ matrix.python-version }} ${{ matrix.runner }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+uv.lock
 # Created by https://www.toptal.com/developers/gitignore/api/python,pycharm+all,vim,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,pycharm+all,vim,visualstudiocode
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 26.5.1
     hooks:
     - id: black
       pass_filenames: true
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.5.3
+    rev: v0.15.20
     hooks:
       - id: ruff
         exclude: _vendor|vendored
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.10.1'  # Use the sha / tag you want to point at
+    rev: 'v2.1.0'  # Use the sha / tag you want to point at
     hooks:
     -   id: mypy
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
     - id: check-yaml
     - id: check-toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ Source = "https://github.com/czaki/tox-min-req"
 testing = [
   "pytest",
   "tox[testing,test]",
-  "coverage"
+  "coverage",
+  "devpi-process>=1.1.1 ; python_version=='3.9'",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ testing = [
   "tox[testing,test]",
   "coverage",
   "devpi-process>=1.0.2 ; python_version=='3.9'",
+  "pytest-mock>=3.14.1 ; python_version=='3.9'",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 name = "tox-min-req"
 description = 'Tox plugin to run tests with minimal requirements base on setup.cfg or pyproject.toml'
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {text = "MIT"}
 keywords = []
 authors = [
@@ -47,9 +47,20 @@ Source = "https://github.com/czaki/tox-min-req"
 [project.optional-dependencies]
 testing = [
   "pytest",
-  "tox[test]",
+  "tox[testing]",
   "coverage"
 ]
+
+[dependency-groups]
+testing = [
+  "pytest",
+  "tox[testing]",
+  "coverage"
+]
+dev = [
+  {include-group = "testing"},
+]
+
 
 [project.entry-points.tox]
 min-req = "tox_min_req._tox_plugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ Source = "https://github.com/czaki/tox-min-req"
 [project.optional-dependencies]
 testing = [
   "pytest",
-  "tox[testing]",
+  "tox[testing,test]",
   "coverage"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ testing = [
   "pytest",
   "tox[testing,test]",
   "coverage",
-  "devpi-process>=1.1.1 ; python_version=='3.9'",
+  "devpi-process>=1.0.2 ; python_version=='3.9'",
 ]
 
 [dependency-groups]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,7 +2,9 @@ import os
 import shutil
 import sys
 from typing import TYPE_CHECKING
+from importlib.metadata import version
 
+from packaging.version import parse as parse_version
 import pytest
 from tox.pytest import ToxProjectCreator, init_fixture  # noqa: F401
 
@@ -430,6 +432,10 @@ def test_reset_pip_constrains(
     result.assert_success()
 
 
+@pytest.mark.skipif(
+    parse_version(version("tox")) >= parse_version("4.36.0"),
+    reason="Since tox 4.36.0, tox raises an error instead of warning for wrong extras",
+)
 def test_warning_wrong_extras(
     tox_project: ToxProjectCreator,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,11 +1,11 @@
 import os
 import shutil
 import sys
-from typing import TYPE_CHECKING
 from importlib.metadata import version
+from typing import TYPE_CHECKING
 
-from packaging.version import parse as parse_version
 import pytest
+from packaging.version import parse as parse_version
 from tox.pytest import ToxProjectCreator, init_fixture  # noqa: F401
 
 from tox_min_req._tox_plugin import CONSTRAINTS_FILE_NAME

--- a/tox_min_req/__init__.py
+++ b/tox_min_req/__init__.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 """tox plugin for simplify minimal requirements tests by creating minimal constrains file."""
+
 from tox_min_req._parse_dependencies import (
     parse_pyproject_toml,
     parse_setup_cfg,
@@ -11,7 +12,7 @@ from tox_min_req._version import __version__
 
 __all__ = (
     "__version__",
-    "parse_setup_cfg",
     "parse_pyproject_toml",
+    "parse_setup_cfg",
     "parse_single_requirement",
 )

--- a/tox_min_req/_parse_dependencies.py
+++ b/tox_min_req/_parse_dependencies.py
@@ -110,7 +110,10 @@ def get_extras_from_dependency(dependency: str) -> Sequence[str]:
     :return: list of extras
     """
     return [
-        x.strip() for x in dependency.split("[")[1].split("]", maxsplit=1)[0].split(",")
+        x.strip()
+        for x in dependency.split("[", maxsplit=2)[1]
+        .split("]", maxsplit=1)[0]
+        .split(",")
     ]
 
 

--- a/tox_min_req/_parse_dependencies.py
+++ b/tox_min_req/_parse_dependencies.py
@@ -20,8 +20,8 @@ else:
 version_constrains = re.compile(r"([a-zA-Z0-9_\-]+)([><=!]+)([0-9\.]+)")
 
 __all__ = (
-    "parse_setup_cfg",
     "parse_pyproject_toml",
+    "parse_setup_cfg",
     "parse_single_requirement",
 )
 
@@ -109,7 +109,9 @@ def get_extras_from_dependency(dependency: str) -> Sequence[str]:
     :param dependency: dependency string
     :return: list of extras
     """
-    return [x.strip() for x in dependency.split("[")[1].split("]")[0].split(",")]
+    return [
+        x.strip() for x in dependency.split("[")[1].split("]", maxsplit=1)[0].split(",")
+    ]
 
 
 def get_all_extras_to_visit(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the minimum supported Python version to 3.8+.
  * Improved test dependency setup with updated extras and added dependency groups.
  * Updated CI to cancel in-progress runs for the same branch and prevent unrelated matrix runs from stopping on failures.
  * Updated version control ignores to exclude the lockfile.
  * Refreshed code quality tooling versions.
* **Bug Fixes**
  * Improved handling of bracketed dependency extras during parsing.
* **Tests**
  * Updated integration tests to be version-aware and conditionally skip behavior that varies by tox version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->