### PR TITLE
feature: Add support for dependency groups

### DIFF
--- a/tests/data/pyproject.toml
+++ b/tests/data/pyproject.toml
@@ -20,3 +20,14 @@ test3 = [
     "sample_package_name[test2]",
     ]
 docs = ["sphinx>=3.0.0"]
+
+
+[dependency-groups]
+tests = [
+    "pytest>=7.0.0",
+    "sample_package_name[test2]",
+    ]
+test2 = [
+    "pytest-mock",
+    {include-group = "tests"},
+]

--- a/tests/data/pyproject.toml
+++ b/tests/data/pyproject.toml
@@ -28,6 +28,10 @@ tests = [
     "sample_package_name[test2]",
     ]
 test2 = [
-    "pytest-mock",
+    "pytest-mock>=3.0.0",
+    {include-group = "tests"},
+]
+test3 = [
+    "pytest-xdist>=3.0.0",
     {include-group = "tests"},
 ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,6 +24,10 @@ commands = pytest test_file.py
 {extras}
 """
 
+TOX_INI_TEMPLATE_GROUPS = TOX_INI_TEMPLATE.replace(
+    "extras = test", "dependency_groups = test"
+)
+
 SETUP_CFG_TEMPLATE = """
 [metadata]
 name = test_package
@@ -63,6 +67,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+test = [
+    "pytest>=7.1.0",
+]
+
+[dependency-groups]
 test = [
     "pytest>=7.1.0",
 ]
@@ -137,6 +146,30 @@ def test_pyproject_toml_parse(
     project = tox_project(
         {
             "tox.ini": TOX_INI_TEMPLATE.format(env=env, extras=""),
+            "pyproject.toml": PYPROJECT_TOML_TEMPLATE,
+            "test_file.py": TEST_FILE_TEMPLATE.format(cmp=cmp),
+        },
+        base=data_dir / "package_data",
+    )
+
+    result = project.run("run")
+
+    result.assert_success()
+
+
+@pytest.mark.parametrize(("cmp", "req"), [("==", "1"), ("!=", "0")])
+def test_pyproject_toml_parse_dependency_groups(
+    tox_project: ToxProjectCreator,
+    monkeypatch: pytest.MonkeyPatch,
+    data_dir: "Path",
+    cmp: str,
+    req: str,
+) -> None:
+    monkeypatch.setenv("MIN_REQ", req)
+    env = f"{sys.version_info[0]}{sys.version_info[1]}"
+    project = tox_project(
+        {
+            "tox.ini": TOX_INI_TEMPLATE_GROUPS.format(env=env, extras=""),
             "pyproject.toml": PYPROJECT_TOML_TEMPLATE,
             "test_file.py": TEST_FILE_TEMPLATE.format(cmp=cmp),
         },

--- a/tests/test_parsing_files.py
+++ b/tests/test_parsing_files.py
@@ -97,13 +97,15 @@ def test_pyproject_toml_parse_dependencies_groups(
         "pytest": "7.0.0",
         "pytest-cov": "2.5",
         "scipy": "1.2.0",
+        "pytest-mock": "3.0.0",
+        "pytest-xdist": "3.0.0",
     }
 
     assert parse_pyproject_toml(
         pyproject_file,
         python_version="3.7",
         python_full_version="3.7.1",
-        dependency_groups=("test2",),
+        dependency_groups=("test2", "test3"),
     ) == {
         "numpy": "1.16.0",
         **constrains,

--- a/tests/test_parsing_files.py
+++ b/tests/test_parsing_files.py
@@ -87,6 +87,29 @@ def test_pyproject_toml_parse(data_dir: Path, monkeypatch: pytest.MonkeyPatch):
     }
 
 
+def test_pyproject_toml_parse_dependencies_groups(
+    data_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr("sys.platform", "linux")
+    pyproject_file = data_dir / "pyproject.toml"
+
+    constrains = {
+        "pytest": "7.0.0",
+        "pytest-cov": "2.5",
+        "scipy": "1.2.0",
+    }
+
+    assert parse_pyproject_toml(
+        pyproject_file,
+        python_version="3.7",
+        python_full_version="3.7.1",
+        dependency_groups=("test2",),
+    ) == {
+        "numpy": "1.16.0",
+        **constrains,
+    }
+
+
 def test_parse_single_requirement():
     p_ver, py_full_ver = "3.10", "3.10.1"
     assert parse_single_requirement("numpy==1.16.0", p_ver, py_full_ver) == {

--- a/tox_min_req/_parse_dependencies.py
+++ b/tox_min_req/_parse_dependencies.py
@@ -37,7 +37,7 @@ def parse_single_requirement(
     :param python_full_version: major.minor.patch version of python
     :return: empty dict if the requirement is not valid or the requirement name and version
     """
-    if line.startswith("{include") or line.startswith("-r") or line.startswith("-c"):
+    if isinstance(line, dict):
         return {}
     req = Requirement(line.split("#", maxsplit=1)[0])
     if req.marker is not None and not req.marker.evaluate(
@@ -183,14 +183,12 @@ def get_all_dependency_groups_to_visit(
             continue
         visited_dependency_groups.add(group)
         for line in dependency_groups[group]:
-            if line.startswith(prefix):
+            if isinstance(line, dict):
+                dependency_groups_to_visit.put(line["include-group"])
+            elif line.startswith(prefix):
                 extras = get_extras_from_dependency(line)
                 required_extras.update(extras)
-            if line.startswith("{include-group"):
-                nested_group = (
-                    line.split("=", maxsplit=1)[1].split("}", maxsplit=1)[0].strip()
-                )
-                dependency_groups_to_visit.put(nested_group)
+
     return visited_dependency_groups, required_extras
 
 

--- a/tox_min_req/_parse_dependencies.py
+++ b/tox_min_req/_parse_dependencies.py
@@ -37,6 +37,8 @@ def parse_single_requirement(
     :param python_full_version: major.minor.patch version of python
     :return: empty dict if the requirement is not valid or the requirement name and version
     """
+    if line.startswith("{include") or line.startswith("-r") or line.startswith("-c"):
+        return {}
     req = Requirement(line.split("#", maxsplit=1)[0])
     if req.marker is not None and not req.marker.evaluate(
         {
@@ -152,11 +154,52 @@ def get_all_extras_to_visit(
     return visited_extras
 
 
+def get_all_dependency_groups_to_visit(
+    dependency_groups: dict[str, list[str]],
+    start_dependency_groups: Sequence[str],
+    project_name: str,
+) -> tuple[set[str], set[str]]:
+    """
+    Get all dependency groups that should be visited.
+
+    :param dependency_groups: dict of the dependency groups
+    :param start_dependency_groups: list of dependency groups to start with
+    :return: set of dependency groups that should be visited and set of required extras
+    """
+    visited_dependency_groups = set()
+    required_extras: set[str] = set()
+    dependency_groups_to_visit: queue.Queue[str] = queue.Queue()
+    prefix = f"{project_name}["
+    for group in start_dependency_groups:
+        dependency_groups_to_visit.put(group)
+    while not dependency_groups_to_visit.empty():
+        group = dependency_groups_to_visit.get()
+        if group in visited_dependency_groups:
+            continue
+        if group not in dependency_groups:
+            warnings.warn(
+                f"Dependency group {group} not found in pyproject.toml", UserWarning
+            )
+            continue
+        visited_dependency_groups.add(group)
+        for line in dependency_groups[group]:
+            if line.startswith(prefix):
+                extras = get_extras_from_dependency(line)
+                required_extras.update(extras)
+            if line.startswith("{include-group"):
+                nested_group = (
+                    line.split("=", maxsplit=1)[1].split("}", maxsplit=1)[0].strip()
+                )
+                dependency_groups_to_visit.put(nested_group)
+    return visited_dependency_groups, required_extras
+
+
 def parse_pyproject_toml(
     path: str | Path,
     python_version: str,
     python_full_version: str,
     extras: Sequence[str] = (),
+    dependency_groups: Sequence[str] = (),
 ) -> dict[str, str]:
     """
     Parse the pyproject.toml file and return a dict of the dependencies and their lower version constraints.
@@ -165,6 +208,7 @@ def parse_pyproject_toml(
     :param python_version: major.minor version of python
     :param python_full_version: major.minor.patch version of python
     :param extras: list of extras to include
+    :param dependency_groups: list of dependency groups to include
     :return: dict of the dependencies that fit to environment and their lower version constraints
     """
     with Path(path).open() as f:
@@ -181,8 +225,19 @@ def parse_pyproject_toml(
         project_name,
     )
 
-    for extra in extras_to_visit:
+    dependency_groups_to_visit, additional_extras = get_all_dependency_groups_to_visit(
+        data["dependency-groups"],
+        dependency_groups,
+        project_name,
+    )
+
+    for extra in extras_to_visit | additional_extras:
         for line in data["project"]["optional-dependencies"][extra]:
+            base_constrains.update(
+                parse_single_requirement(line, python_version, python_full_version)
+            )
+    for group in dependency_groups_to_visit:
+        for line in data["dependency-groups"][group]:
             base_constrains.update(
                 parse_single_requirement(line, python_version, python_full_version)
             )

--- a/tox_min_req/_parse_dependencies.py
+++ b/tox_min_req/_parse_dependencies.py
@@ -184,7 +184,12 @@ def get_all_dependency_groups_to_visit(
         visited_dependency_groups.add(group)
         for line in dependency_groups[group]:
             if isinstance(line, dict):
-                dependency_groups_to_visit.put(line["include-group"])
+                if "include-group" in line:
+                    dependency_groups_to_visit.put(line["include-group"])
+                else:  # pragma: no cover
+                    warnings.warn(
+                        f"Invalid line format in dependency group {group}: {line}"
+                    )
             elif line.startswith(prefix):
                 extras = get_extras_from_dependency(line)
                 required_extras.update(extras)

--- a/tox_min_req/_parse_dependencies.py
+++ b/tox_min_req/_parse_dependencies.py
@@ -141,7 +141,7 @@ def get_all_extras_to_visit(
         extra = extras_to_visit.get()
         if extra in visited_extras:
             continue
-        if extra not in optional_dependencies:
+        if extra not in optional_dependencies:  # pragma: no cover
             warnings.warn(f"Extra {extra} not found in pyproject.toml", UserWarning)
             continue
         visited_extras.add(extra)
@@ -176,7 +176,7 @@ def get_all_dependency_groups_to_visit(
         group = dependency_groups_to_visit.get()
         if group in visited_dependency_groups:
             continue
-        if group not in dependency_groups:
+        if group not in dependency_groups:  # pragma: no cover
             warnings.warn(
                 f"Dependency group {group} not found in pyproject.toml", UserWarning
             )

--- a/tox_min_req/_parse_dependencies.py
+++ b/tox_min_req/_parse_dependencies.py
@@ -219,17 +219,26 @@ def parse_pyproject_toml(
             parse_single_requirement(line, python_version, python_full_version)
         )
     project_name = data["project"]["name"]
-    extras_to_visit = get_all_extras_to_visit(
-        data["project"]["optional-dependencies"],
-        extras,
-        project_name,
-    )
+    if extras:
+        extras_to_visit = get_all_extras_to_visit(
+            data["project"]["optional-dependencies"],
+            extras,
+            project_name,
+        )
+    else:
+        extras_to_visit = set()
 
-    dependency_groups_to_visit, additional_extras = get_all_dependency_groups_to_visit(
-        data["dependency-groups"],
-        dependency_groups,
-        project_name,
-    )
+    if dependency_groups:
+        dependency_groups_to_visit, additional_extras = (
+            get_all_dependency_groups_to_visit(
+                data["dependency-groups"],
+                dependency_groups,
+                project_name,
+            )
+        )
+    else:
+        dependency_groups_to_visit = set()
+        additional_extras = set()
 
     for extra in extras_to_visit | additional_extras:
         for line in data["project"]["optional-dependencies"][extra]:

--- a/tox_min_req/_tox_plugin.py
+++ b/tox_min_req/_tox_plugin.py
@@ -66,13 +66,18 @@ def tox_on_install(tox_env: ToxEnv, arguments: Any, section: str, of_type: str) 
     python_version = ".".join(str(x) for x in tox_env.base_python.version_info[:2])
     python_full_version = ".".join(str(x) for x in tox_env.base_python.version_info[:3])
     extras = tox_env.conf["extras"]
+    dependency_groups = tox_env.conf["dependency_groups"]
     if (project_path / "setup.cfg").exists():
         dependencies = parse_setup_cfg(
             project_path / "setup.cfg", python_version, python_full_version, extras
         )
     elif (project_path / "pyproject.toml").exists():
         dependencies = parse_pyproject_toml(
-            project_path / "pyproject.toml", python_version, python_full_version, extras
+            project_path / "pyproject.toml",
+            python_version,
+            python_full_version,
+            extras,
+            dependency_groups,
         )
     else:  # pragma: no cover
         return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reading `pyproject.toml` `[dependency-groups]` alongside existing optional dependencies.
  * Tox now applies configured dependency groups during dependency resolution, including nested `include-group` handling and group-driven extra requirements.
* **Bug Fixes**
  * Improved robustness when parsing unexpected non-string requirement entries.
* **Tests**
  * Added integration and parsing tests to validate dependency-group behavior, including nested groups and coverage across different minimum requirement values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->